### PR TITLE
Add Travis CI support for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,59 +5,91 @@ matrix:
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=py27
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=py27
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=0
+        - python: 2.7
+          os: linux
+          dist: precise
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
+        - python: 2.7
+          os: linux
+          dist: trusty
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
         - python: 3.4
           os: linux
           dist: precise
-          env: TOXENV=py34
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=0
         - python: 3.4
           os: linux
           dist: trusty
-          env: TOXENV=py34
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=0
+        - python: 3.4
+          os: linux
+          dist: precise
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=1
+        - python: 3.4
+          os: linux
+          dist: trusty
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=1
         - python: 3.5
           os: linux
           dist: precise
-          env: TOXENV=py35
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=0
         - python: 3.5
           os: linux
           dist: trusty
-          env: TOXENV=py35
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=0
+        - python: 3.5
+          os: linux
+          dist: precise
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=1
+        - python: 3.5
+          os: linux
+          dist: trusty
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=1
         - python: 3.6
           os: linux
           dist: precise
-          env: TOXENV=py36
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=0
         - python: 3.6
           os: linux
           dist: trusty
-          env: TOXENV=py36
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=0
+        - python: 3.6
+          os: linux
+          dist: precise
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
+        - python: 3.6
+          os: linux
+          dist: trusty
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=pep8
+          env: TOXENV=pep8 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=pep8
+          env: TOXENV=pep8 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=bandit
+          env: TOXENV=bandit RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=bandit
+          env: TOXENV=bandit RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=docs
+          env: TOXENV=docs RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=docs
+          env: TOXENV=docs RUN_INTEGRATION_TESTS=0
 install:
   # Pin six to >= 1.11.0 to avoid cherrypy/cheroot dependency errors
   # For more info, see: https://github.com/OpenKMIP/SLUGS/issues/3
@@ -68,6 +100,6 @@ install:
   - pip install codecov
   - python setup.py install
 script:
-  - tox
+  - ./.travis/run.sh
 after_success:
   - codecov

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "${RUN_INTEGRATION_TESTS}" == "1" ]]; then
+    sudo mkdir -p /etc/slugs
+    sudo cp ./.travis/slugs.conf /etc/slugs/slugs.conf
+    sudo cp ./.travis/user_group_mapping.csv /etc/slugs/user_group_mapping.csv
+    sudo mkdir -p /var/log/cherrypy/slugs
+    sudo chmod 777 /var/log/cherrypy/slugs
+    slugs -c /etc/slugs/slugs.conf &
+    tox -r -e integration -- --url http://127.0.0.1:8080/slugs
+else
+    tox
+fi

--- a/.travis/slugs.conf
+++ b/.travis/slugs.conf
@@ -1,0 +1,12 @@
+[global]
+environment = 'production'
+server.socket_host = '127.0.0.1'
+server.socket_port = 8080
+log.access_file = '/var/log/cherrypy/slugs/access.log'
+log.error_file = '/var/log/cherrypy/slugs/error.log'
+
+[data]
+user_group_mapping = '/etc/slugs/user_group_mapping.csv'
+
+[/slugs]
+tools.trailing_slash.on = True

--- a/.travis/user_group_mapping.csv
+++ b/.travis/user_group_mapping.csv
@@ -1,0 +1,4 @@
+John,Human
+Jane,Human
+John,Male
+Jane,Female


### PR DESCRIPTION
This change adds integration testing support to the Travis CI configuration used by SLUGS. Now, the Travis CI will instantiate and run a version SLUGS and will run the integration test suite against it to verify live functionality.