### PR TITLE
Fix copyright notices

### DIFF
--- a/slugs/app.py
+++ b/slugs/app.py
@@ -1,4 +1,4 @@
-# Copyright 2017, The Johns Hopkins University/Applied Physics Laboratory
+# Copyright 2018, The Johns Hopkins University/Applied Physics Laboratory
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/slugs/plugins.py
+++ b/slugs/plugins.py
@@ -1,4 +1,4 @@
-# Copyright 2017, The Johns Hopkins University/Applied Physics Laboratory
+# Copyright 2018, The Johns Hopkins University/Applied Physics Laboratory
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/slugs/tests/unit/test_app.py
+++ b/slugs/tests/unit/test_app.py
@@ -1,4 +1,4 @@
-# Copyright 2017, The Johns Hopkins University/Applied Physics Laboratory
+# Copyright 2018, The Johns Hopkins University/Applied Physics Laboratory
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/slugs/tests/unit/test_controllers.py
+++ b/slugs/tests/unit/test_controllers.py
@@ -1,4 +1,4 @@
-# Copyright 2017, The Johns Hopkins University/Applied Physics Laboratory
+# Copyright 2018, The Johns Hopkins University/Applied Physics Laboratory
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/slugs/tests/unit/test_plugins.py
+++ b/slugs/tests/unit/test_plugins.py
@@ -1,4 +1,4 @@
-# Copyright 2017, The Johns Hopkins University/Applied Physics Laboratory
+# Copyright 2018, The Johns Hopkins University/Applied Physics Laboratory
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may


### PR DESCRIPTION
This change updates several source code copyright notices. The provided year was entered incorrectly, indicating 2017 when 2018 was the correct value. This change corrects these mistakes.