### PR TITLE
Manually install setuptools_scm via pip to avoid easy_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,8 @@ install:
   # For more info, see: https://github.com/OpenKMIP/SLUGS/issues/3
   - pip uninstall -y six
   - pip install six>=1.11.0
+  # Fill this in...
+  - pip install setuptools_scm
   - pip install tox
   - pip install bandit
   - pip install codecov


### PR DESCRIPTION
This change updates the .travis.yml install setup steps to manually install setuptools_scm, an indirect project dependency, via pip. If it is installed using easy_install, subsequent dependency installs that use setuptools_scm features can fail to preserve package versioning information. The dependency will be installed as version 0.0.0 which breaks minimum version enforcement. Installing setuptools_scm via pip avoids this case, allowing the dependencies to be installed with the correct version numbers.

Fixes #15