### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,30 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
+#        - python: 3.7
+#          os: linux
+#          dist: precise
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=0
+#        - python: 3.7
+#          os: linux
+#          dist: trusty
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=0
+        - python: 3.7
+          os: linux
+          dist: xenial
+          env: TOXENV=py37 RUN_INTEGRATION_TESTS=0
+#        - python: 3.7
+#          os: linux
+#          dist: precise
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=1
+#        - python: 3.7
+#          os: linux
+#          dist: trusty
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=1
+        - python: 3.7
+          os: linux
+          dist: xenial
+          env: TOXENV=py37 RUN_INTEGRATION_TESTS=1
         - python: 2.7
           os: linux
           dist: precise

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py27,py34,py35,py36,bandit,docs
+envlist = pep8,py27,py34,py35,py36,py37,bandit,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This change adds Python 3.7 support to SLUGS. Updates have been made to the tox and Travis CI configuration files to verify that SLUGS runs and passes its test when run under Python 3.7.

Closes #9 